### PR TITLE
Remove link to /r/ledger: ledger subreddit is defunct

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ You might also like [awesome-beancount](https://github.com/wzyboy/awesome-beanco
 
 ## Social
 
-- [Reddit](https://www.reddit.com/r/ledger/) - Ledger subreddit.
 - [Twitter](https://twitter.com/LedgerTips) - Usage tips.
 - [Google Group](https://groups.google.com/forum/#!forum/ledger-cli) - Ledger Google Group.
 - [Stack Exchange](https://money.stackexchange.com/search?q=ledger-cli) - Tag on “Personal Finance & Money Stack”.


### PR DESCRIPTION
also it was most recently used for the ledger hardward wallet, not ledger CLI.