### PR TITLE
Update link to awesome-beancount

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Useful resources for the [Ledger](http://ledger-cli.org/) command-line accounting system
 
-You might also like [awesome-beancount](https://github.com/wzyboy/awesome-beancount).
+You might also like [awesome-beancount](https://github.com/siddhantgoel/awesome-beancount).
 
 *Please read the [contribution guidelines](contributing.md) before contributing.*
 


### PR DESCRIPTION
The `awesome-beancount` project currently linked to has unfortunately not been updated since 2016.

The proposed replacement is being actively maintained (by me), has become much more exhaustive at this point, and is also being deployed to https://awesome-beancount.com.